### PR TITLE
Update Dockerfile to pull updated dependencies and fixed fork of `pgloader`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as builder
+FROM debian:bookworm-slim as builder
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -9,7 +9,7 @@ RUN apt-get update && \
         gawk \
         git \
         libsqlite3-dev \
-        libssl1.1 \
+        libssl3 \
         libzip-dev \
         make \
         openssl \
@@ -24,7 +24,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN wget -O /tmp/pgloader.tar.gz -L \
-        "https://github.com/dimitri/pgloader/archive/refs/heads/master.tar.gz" && \
+        "https://github.com/tobz/pgloader/archive/refs/heads/master.tar.gz" && \
     tar xf \
         /tmp/pgloader.tar.gz -C /opt/src/pgloader --strip-components=1
 
@@ -32,7 +32,7 @@ RUN mkdir -p /opt/src/pgloader/build/bin && \
     cd /opt/src/pgloader && \
     make DYNSIZE=32768 clones save
 
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
 LABEL maintainer=Roxedus
 


### PR DESCRIPTION
This PR does two things:

- it switches to `debian:bookworm` just to pin the actual release being used (`stable` worked the last time you built, but now that `bookworm` is the stable release, `libssl1.1` isn't a thing anymore, etc... so pinning to `bookworm` solves that
- switches to my fork of the `pgloader` repo which is a fork of `codereverser/pgloader` which includes a branch for fixing a glitch with [quoted identifiers and resetting sequences](https://github.com/dimitri/pgloader/pull/1509)